### PR TITLE
fixed position offset when seq softclipped or indel within primer seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Supports filtering of superamplicons/chimeric PCR products.
 `ampliconfilter.py --help`  for command line options.
 
 NB: This program implements a standard bisection algorithm to find matching primers.
+
+## Releases
+
+### v1.0
+
+- initial release
+
+### v1.0.1
+
+- fixed an offset error that occured in about 1/1000 reads when the primer sequence contained an indel or was part softclipped

--- a/ampliconFilter.py
+++ b/ampliconFilter.py
@@ -81,7 +81,7 @@ def primerClip(alnread,primers,globalstat,extratrim,mask,clipping=0,maskadaptor=
     This will not adjust the mate positions (use sync_mate_pos)
 
     Returns:
-        the clipped primer or None if no sequence remains
+        the primer clipped pysam.AlignedSegment, or None if no sequence remains
     """
     # get primer positions and sequence for read pair
     newqual, newseq, lprimer, rprimer = '','','',''
@@ -267,15 +267,15 @@ matchstring = lambda x,y: ''.join(['*' if n == y[i] else "-" for i,n in enumerat
 """reverse complement"""
 revcomp = lambda x: ''.join([{'A':'T','C':'G','G':'C','T':'A'}[B] for B in x][::-1])
 
-def sync_mate_pos(x,y):
+def sync_mate_pos(x, y):
     """
     Inputs:
-        a pair of alignments
+        a pair of pysam.AlignedSegments
 
-    Checks for query name match and adjust mate positions
+    Checks for query name match and adjust mate positions respectively
 
     Returns:
-        the same pair with adjusted mate position
+        the same pair with fixed mate positions
     """
     if x.qname == y.qname:
         x.pnext, y.pnext = y.pos, x.pos

--- a/ampliconFilter.py
+++ b/ampliconFilter.py
@@ -68,7 +68,6 @@ def readBedPe(fi,genome_fasta):
 def primerClip(alnread,primers,globalstat,extratrim,mask,clipping=0,maskadaptor=True):
     """
     Inputs:
-        output file handle
         pysam aligned_pair
         matched primers (list of Segment objects)
         dictionary to collect statistics
@@ -191,14 +190,15 @@ def primerClip(alnread,primers,globalstat,extratrim,mask,clipping=0,maskadaptor=
                 newseq = newseq[leftprimerend:riteprimerstart]
                 newqual = newqual[leftprimerend:riteprimerstart]
         # change position (needs to be adjusted if begins with softclip on fwd strand)
-        # first operation that consumes reference (MDN=X)
+        # first operation that consumes reference (CIGAR operations MDN=X)
         first_reference_base = 0
-        for o, l in newcigartuples:
-            if o in [0,2,3,7,8]:
+        for o, l in newcigartuples:  # (numeric operation code, length of operation) from CIGAR string
+            if o in (0,2,3,7,8):  #  break at first reference sequence consuming CIGAR operation
                 break
             first_reference_base += l
         # extract aligned position corresponding to new first reference base
         try:
+            # extract reference position of position in query (https://pysam.readthedocs.io/en/latest/api.html#pysam.AlignedSegment.get_aligned_pairs)
             newpos = alnread.get_aligned_pairs()[first_reference_base][1] 
             assert newpos
         except:


### PR DESCRIPTION
## The issue
As seen by and discussed with Rebecca, some reads (approx 1/1000) would be offset by a few bases if the primer sequence in the input already had some soft clipped bases or insertions within the primer sequence. This is rare as we do not expect Indels or softclipping (due to low BQ) within the primer sequence. The variant caller would discard such reads as they have an excessive amount of mismatched bases, and thus would not decrease specificity and only very marginally reduce sensitivity.

### The fix
Fixed by recalculating the correct start position _after_ the CIGAR string and sequences have been edited. This ensures that the position is correct and reflects the clipping/masking of the original read.

## Additional bugfixes
While implementing this, two other minor issues were addressed:

### Mate position
Fix a minor issue with the mate position in the output BAM file.
The script now ensures that the reads within a pair refer to the right position of their mate.
This does not affect the downstream processing as it is generally ignored by short variant callers (and IGV).

### Alignments without any sequence after primer clipped (meet SAM spec)
If one end of the read pair will have no aligned sequence left after primer clipping (eg. only S operations in the CIGAR string), the whole pair is now discarded. This ensures that CIGAR strings are now fully according to spec and cannot contain only S operations.

## Verification
The changes are minor and do not change the overall behaviour of the script, nor do they add any new functionality. Therefore a verification of a Swift57 run at the VCF level is sufficient.
I would suggest comparing VCF output of the same run between v1.0.0 and v1.0.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/ampliconfilter/2)
<!-- Reviewable:end -->
