### PR TITLE
fixed pysam install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.7
+FROM python:buster
 RUN apt-get update && apt-get install -y samtools
-RUN pip3 install pysam==0.15.4 cython==0.29.19 
+RUN pip3 install cython==0.29.24
+RUN pip3 install pysam==0.15.4
 RUN mkdir /code /sandbox /resources
 WORKDIR /code
 ADD . /code
 
-ENTRYPOINT ["/code/ampliconfilter/ampliconFilter.py"]
+# ENTRYPOINT ["/usr/local/bin/python"]
+CMD ["./ampliconFilter.py"]
 

--- a/ampliconFilter.py
+++ b/ampliconFilter.py
@@ -400,7 +400,7 @@ if __name__=="__main__":
     ts = time.time()
     # mandatory arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('designfile', help='file with the amplicon design (from Qiagen)')
+    parser.add_argument('designfile', metavar='BEDPE', help='BEDPE file with the amplicon design')
     parser.add_argument('-m','--metrics', metavar='FILE', help='Metrics output', type=str)
     # I/O
     parser.add_argument('-i','--inputfile', metavar='FILE', help='inputfile (Default: SAM to STDIN)', type=str)

--- a/samclip.py
+++ b/samclip.py
@@ -85,9 +85,10 @@ def clip_primers(args):
 
     # run samtools and capture output
     sys.stderr.write('Running ampliconclip...\n')
-    p = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, shell=True)
-    alignments = pysam.AlignmentFile(p.stdout, "rb")
-
+    with (open(args.metrics,'w') if args.metrics else sys.stderr) as metrics_out:
+        proc = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, stderr=metrics_out, shell=True)
+        alignments = pysam.AlignmentFile(proc.stdout, "rb")
+    
     # iterare over alignment and write output
     outfile = bamIO(args.outfile, 'w', True, alignments)
     buffer = []
@@ -116,7 +117,8 @@ if __name__=="__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('bedfile', metavar='BED', help='BED file of primer locations (with strand)')
     parser.add_argument('bamfile', metavar='BAM', help='BAM input file')
-    parser.add_argument('-o','--outfile', metavar='FILE', help='outputfile (STDOUT)')
+    parser.add_argument('-o','--outfile', metavar='FILE', help='outputfile [STDOUT]')
+    parser.add_argument('-m','--metrics', metavar='FILE', help='Metrics output from samtools ampliconclip [STDERR]')
     parser.add_argument('-r','--rejects', metavar='FILE', help='Rejected reads (optional)')
     args = parser.parse_args()
 


### PR DESCRIPTION
Docker file now build correctly.

Entrypoint remains python per default.

Usage Example:

`docker run -it --rm seglh/ampliconfilter ampliconFilter.py design.bedpe -g hs37d5.fa --clipping 1 --super --maxbuffer 10000000 -I namesorted.bam -o output.bam -d discarded.bam -m output.metrics`

or

`docker run -it --rm seglh/ampliconfilter samclip.py -o output.bam -r rejected.bam -m output.metrics design.bed input.bam`

Changed helper text for ampliconfilter.

Updated samclip.py to allow writing of metrics to file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/ampliconfilter/6)
<!-- Reviewable:end -->
